### PR TITLE
Fix warning in brew about deprecated use of "devel"

### DIFF
--- a/ethereum.rb
+++ b/ethereum.rb
@@ -3,7 +3,7 @@ class Ethereum < Formula
   homepage "https://github.com/ethereum/go-ethereum"
   url "https://github.com/ethereum/go-ethereum.git", :tag => "v1.9.15"
 
-  devel do
+  head do
     url "https://github.com/ethereum/go-ethereum.git", :branch => "master"
   end
 


### PR DESCRIPTION
error message:

```
Warning: Calling 'devel' blocks in formulae is deprecated! Use 'head' blocks or @-versioned formulae instead.
Please report this issue to the ethereum/ethereum tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/ethereum/homebrew-ethereum/ethereum.rb:6
```